### PR TITLE
Use a debian-based image to run the Linux tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.5
+MAINTAINER Zhang Xianyi <traits.zhang@gmail.com>
+
+RUN apt-get update -yqq \
+  && apt-get install -yqq gfortran \
+  && rm -rf /var/lib/apt/lists/*

--- a/full_test_linux.sh
+++ b/full_test_linux.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-#    docker run --rm -v $PWD:/io quay.io/pypa/manylinux1_x86_64 /io/full_test_linux.sh ${build_string}
+# docker build -t xianyi/openblas-ci .
+# docker run --rm -v $PWD:/io xianyi/openblas-ci /io/${script_name} "${build_arg}"
 set -e
 git clone https://github.com/xianyi/OpenBLAS
 git clone https://github.com/xianyi/BLAS-Tester
@@ -22,7 +23,6 @@ echo "Running BLAS-Tester"
 /io/run_blas_tester.sh
 
 # Run python tests
-export PATH=/opt/2.7/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 pip install "cython==0.23.5" nose
 pip install "numpy==1.10.4"

--- a/quick_test_linux.sh
+++ b/quick_test_linux.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-#    docker run --rm -v $PWD:/io quay.io/pypa/manylinux1_x86_64 /io/quick_test_linux.sh ${build_string}
+# docker build -t xianyi/openblas-ci .
+# docker run --rm -v $PWD:/io xianyi/openblas-ci /io/${script_name} "${build_arg}"
 set -e
 git clone https://github.com/xianyi/OpenBLAS
 cd OpenBLAS

--- a/run_test_helper.sh
+++ b/run_test_helper.sh
@@ -6,4 +6,5 @@ build_arg=$2
 echo ${script_name}
 echo ${build_arg}
 
-docker run --rm -v $PWD:/io quay.io/pypa/manylinux1_x86_64 /io/${script_name} "${build_arg}"
+docker build -t xianyi/openblas-ci .
+docker run --rm -v $PWD:/io xianyi/openblas-ci /io/${script_name} "${build_arg}"


### PR DESCRIPTION
This should fix the numpy test failure caused by an old version of glibc.
