### PR TITLE
Run the scipy stack tests under OSX

### DIFF
--- a/full_test_osx.sh
+++ b/full_test_osx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ./full_test_osx.sh ${build_string} ${CORETYPE}
-set -e
+set -ex
 
 BTYPE=$1
 CORETYPE=$2

--- a/full_test_osx.sh
+++ b/full_test_osx.sh
@@ -17,5 +17,34 @@ make -C test NUM_THREADS=64 $BTYPE
 make -C ctest NUM_THREADS=64 $BTYPE
 make -C utest NUM_THREADS=64 $BTYPE
 make NUM_THREADS=64 $BTYPE lapack-test
+mkdir -p /opt
+make NUM_THREADS=64 $BTYPE PREFIX=/opt/OpenBLAS install
 
+# gfortran is provided by Homebrew as part of the gcc package
+brew update
+brew install gcc
+
+# Run python tests
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+pip install "cython==0.23.5" nose
+pip install --no-binary=:all: "numpy==1.10.4"
+pip install --no-binary=:all: "scipy==0.17.0"
+pip install --no-binary=:all: "scikit-learn==0.17.1"
+
+function np_test {
+    local pkg_name=$1
+    local extra_args=$2
+    python -c "import sys; \
+        import $pkg_name; \
+        result = $pkg_name.test($extra_args); \
+        sys.exit(not result.wasSuccessful())"
+}
+
+# Workaround for f2py install issue:
+echo -e '#!/usr/bin/env python\nfrom numpy import f2py\nf2py.main()' > /usr/bin/f2py
+chmod +x /usr/bin/f2py
+
+np_test numpy '"full", verbose=3'
+np_test scipy '"full", verbose=3'
+nosetests -v sklearn
 echo "Finish"


### PR DESCRIPTION
This requires to have http://brew.sh/ installed on the buildbox slave. It's it's not the case it's possible to install it with the following command:

```
/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
```

either once and for all or inside the `full_test_osx.sh` script itself.
