### PR TITLE
Run Python tests from within user folder only

### DIFF
--- a/full_test_osx.sh
+++ b/full_test_osx.sh
@@ -17,15 +17,22 @@ make -C test NUM_THREADS=64 $BTYPE
 make -C ctest NUM_THREADS=64 $BTYPE
 make -C utest NUM_THREADS=64 $BTYPE
 make NUM_THREADS=64 $BTYPE lapack-test
-mkdir -p /opt
-make NUM_THREADS=64 $BTYPE PREFIX=/opt/OpenBLAS install
-
-# gfortran is provided by Homebrew as part of the gcc package
-brew update
-brew install gcc
+mkdir -p $HOME/opt
+make NUM_THREADS=64 $BTYPE PREFIX=$HOME/opt/OpenBLAS install
+export LD_LIBRARY_PATH=$HOME/opt/OpenBLAS/lib:$LD_LIBRARY_PATH
 
 # Run python tests
-export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+cd $HOME
+export VENV=$HOME/venv
+pip install --user --upgrade virtualenv
+rm -rf $VENV && python -m virtualenv $VENV
+source $VENV/bin/activate
+
+cat << EOF > $HOME/site.cfg
+[openblas]
+library_dirs = $HOME/opt/OpenBLAS/lib
+include_dirs = $HOME/opt/OpenBLAS/include
+EOF
 pip install "cython==0.23.5" nose
 pip install --no-binary=:all: "numpy==1.10.4"
 pip install --no-binary=:all: "scipy==0.17.0"
@@ -41,8 +48,8 @@ function np_test {
 }
 
 # Workaround for f2py install issue:
-echo -e '#!/usr/bin/env python\nfrom numpy import f2py\nf2py.main()' > /usr/bin/f2py
-chmod +x /usr/bin/f2py
+echo -e '#!/usr/bin/env python\nfrom numpy import f2py\nf2py.main()' > $VENV/bin/f2py
+chmod +x $VENV/bin/f2py
 
 np_test numpy '"full", verbose=3'
 np_test scipy '"full", verbose=3'


### PR DESCRIPTION
This is a followup on #11. I tested it locally on my laptop, I hope this time it will work.
It requires gfortran in the PATH of the buildbot worker image but I believe it is already installed.
